### PR TITLE
fix: landing page — remove CDN dependencies, use system fonts

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Queryx — Agent-native search API</title>
   <link rel="stylesheet" href="styles.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 </head>
 <body>
 

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -15,8 +15,8 @@
   --muted: #71717a;
   --green: #10b981;
   --red: #ef4444;
-  --font: 'Inter', system-ui, -apple-system, sans-serif;
-  --mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font: system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, 'Fira Code', 'Cascadia Code', Consolas, monospace;
 }
 
 html {


### PR DESCRIPTION
Closes #3

## Changes

### Removed CDN dependencies (spec requirement: "no CDN dependencies")

The previous implementation loaded Inter and JetBrains Mono from Google Fonts CDN:
```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link href="https://fonts.googleapis.com/css2?family=Inter..." rel="stylesheet">
```

This violates the spec and adds ~200ms latency on first load.

**Fix:** Replaced with system font stack — zero external requests, loads instantly.

```css
--font: system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
--mono: ui-monospace, 'Fira Code', 'Cascadia Code', Consolas, monospace;
```

### Result
- ✅ Zero CDN dependencies
- ✅ Faster initial load (no font fetch roundtrip)
- ✅ All 5 sections intact: Hero, Pricing, Quick start, How it works, Footer
- ✅ Dark theme: bg #0a0a0a, surface #141414, accent #6366F1
- ✅ Mobile responsive