### PR TITLE
Add OpenAPI and agent discovery docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -13,12 +13,48 @@
 | `POST /v1/search/deep` | $0.005 | Multi-source deep research |
 | `GET /health` | Free | Health check |
 
+## Local Development
+
+```bash
+bun install
+bun test
+bun run typecheck
+bun run dev
+```
+
+The server entrypoint exports `default { port, fetch }`, so Bun, Railway, and tests can mount the app without a manual `Bun.serve()` call.
+
+## Environment
+
+Copy `.env.example` and configure:
+
+| Variable | Purpose |
+|----------|---------|
+| `PAYMENTS_RECEIVABLE_ADDRESS` | USDC receivable wallet for x402 payments on Base |
+| `FACILITATOR_URL` | x402 facilitator URL |
+| `NETWORK` | Payment network label, defaults to `base` for route challenges |
+| `BRAVE_API_KEY` | Brave Search API key for live search |
+| `OPENAI_API_KEY` | GPT-4o-mini synthesis key |
+| `PORT` | Bun server port |
+| `CACHE_TTL_SECONDS` | In-memory cache TTL |
+
+## Payment Behavior
+
+Paid endpoints return HTTP `402` with x402 payment details when no payment header is present. For contract tests only, `x402-test-payment: valid` bypasses settlement and uses deterministic fixture data.
+
 ## Quick Start (agent)
 
 ```bash
 curl -H "PAYMENT-SIGNATURE: <x402-sig>" \
   "https://queryx.run/v1/search?q=Fed+rate+decision+impact+on+tech+stocks"
 ```
+
+## Agent Discovery
+
+- OpenAPI 3.1 spec: [`openapi.json`](openapi.json)
+- Agent usage guide: [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md)
+- Pricing details: [`docs/PRICING.md`](docs/PRICING.md)
+- xgate.run listing metadata: [`docs/XGATE_LISTING.md`](docs/XGATE_LISTING.md)
 
 ## Stack
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,160 @@
+# Queryx Agent Guide
+
+Queryx is a paid JSON search API for autonomous agents. Use it when an agent needs current web evidence, recent news, or a deeper multi-source synthesis without creating an account.
+
+## Base URL
+
+Production:
+
+```text
+https://queryx.run
+```
+
+Local development:
+
+```text
+http://localhost:3000
+```
+
+## Endpoints
+
+| Endpoint | Method | Price | Use |
+| --- | --- | ---: | --- |
+| `/v1/search` | `GET` | `0.001` USDC | General web search and synthesis |
+| `/v1/search/news` | `GET` | `0.001` USDC | Recent news-oriented search |
+| `/v1/search/deep` | `POST` | `0.005` USDC | Deeper multi-source research |
+| `/health` | `GET` | Free | Service readiness |
+
+## Payment Flow
+
+Queryx uses x402 payment challenges.
+
+1. Send the intended request without a payment header.
+2. Read the `402 Payment Required` response.
+3. Parse either `WWW-Authenticate` or `X-Accepted-Payment`.
+4. Sign the returned payment challenge with an x402-compatible wallet on the declared network.
+5. Retry the same request with one of these headers:
+
+```text
+X-PAYMENT: <serialized x402 payment>
+PAYMENT: <serialized x402 payment>
+PAYMENT-SIGNATURE: <compatible payment signature>
+```
+
+Agents should treat the JSON `error.details` object in the 402 response as the canonical payment metadata. It includes:
+
+| Field | Meaning |
+| --- | --- |
+| `price` | Endpoint price in USDC |
+| `payTo` | Receivable wallet address |
+| `network` | Payment network, default `base` |
+| `facilitatorUrl` | x402 facilitator used for settlement |
+| `x402Version` | Payment protocol version |
+
+## Example: Get A Payment Challenge
+
+```bash
+curl -i "https://queryx.run/v1/search?q=bitcoin%20ETF%20flows"
+```
+
+Expected response:
+
+```http
+HTTP/1.1 402 Payment Required
+WWW-Authenticate: x402 <challenge>
+X-Accepted-Payment: <challenge>
+Content-Type: application/json
+```
+
+```json
+{
+  "error": {
+    "code": "PAYMENT_REQUIRED",
+    "message": "x402 payment is required for this endpoint",
+    "details": {
+      "price": "0.001",
+      "payTo": "0x0000000000000000000000000000000000000000",
+      "network": "base",
+      "facilitatorUrl": "https://facilitator.daydreams.systems",
+      "x402Version": 2
+    }
+  }
+}
+```
+
+## Example: Paid Web Search
+
+```bash
+curl \
+  -H "X-PAYMENT: <serialized-x402-payment>" \
+  "https://queryx.run/v1/search?q=Fed%20rate%20decision%20impact%20on%20tech%20stocks"
+```
+
+Response shape:
+
+```json
+{
+  "query": "Fed rate decision impact on tech stocks",
+  "answer": "A concise synthesized answer for the agent.",
+  "sources": [
+    {
+      "title": "Source title",
+      "url": "https://example.com/source",
+      "snippet": "Evidence excerpt.",
+      "published": "2026-05-11T04:00:00.000Z"
+    }
+  ],
+  "confidence": 0.78,
+  "freshness": {
+    "fetchedAt": "2026-05-11T04:00:00.000Z",
+    "resultsAge": "1 hour"
+  },
+  "model": "queryx-fast-v1",
+  "tokens": {
+    "in": 31,
+    "out": 256
+  }
+}
+```
+
+## Example: Paid News Search
+
+```bash
+curl \
+  -H "X-PAYMENT: <serialized-x402-payment>" \
+  "https://queryx.run/v1/search/news?q=latest%20ethereum%20ETF%20inflows"
+```
+
+Use this endpoint when recency matters more than evergreen relevance.
+
+## Example: Paid Deep Search
+
+```bash
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: <serialized-x402-payment>" \
+  -d '{"query":"Compare Brave, Tavily, and Perplexity pricing for agent search","depth":"deep"}' \
+  "https://queryx.run/v1/search/deep"
+```
+
+Use this endpoint for comparison, diligence, and multi-source synthesis tasks.
+
+## Error Handling
+
+| Status | Code | Agent behavior |
+| ---: | --- | --- |
+| `400` | `BAD_REQUEST` | Fix missing or invalid query input and retry. |
+| `402` | `PAYMENT_REQUIRED` | Complete the x402 payment flow and retry the same request. |
+| `422` | `BAD_REQUEST` | Fix malformed JSON body and retry. |
+| `429` | `RATE_LIMITED` | Back off and retry later. |
+| `500` | `INTERNAL_ERROR` | Retry with exponential backoff or fall back to another source. |
+
+## Best Practices
+
+- Cache identical queries client-side when freshness is not critical.
+- Use `/v1/search/news` only for explicitly time-sensitive questions.
+- Use `/v1/search/deep` for tasks that need cross-source reconciliation.
+- Preserve returned `sources` with any downstream answer to keep auditability.
+- Do not reuse a payment challenge across materially different requests unless the x402 facilitator explicitly permits it.
+

--- a/docs/PRICING.md
+++ b/docs/PRICING.md
@@ -1,0 +1,50 @@
+# Queryx Pricing
+
+Queryx charges per request using x402 USDC payments.
+
+## Endpoint Prices
+
+| Endpoint | Method | Price (USDC) | Base units, 6 decimals | Intended use |
+| --- | --- | ---: | ---: | --- |
+| `/v1/search` | `GET` | `0.001` | `1000` | Web search and synthesis |
+| `/v1/search/news` | `GET` | `0.001` | `1000` | Recent news search |
+| `/v1/search/deep` | `POST` | `0.005` | `5000` | Deeper multi-source research |
+| `/health` | `GET` | `0` | `0` | Health checks |
+
+## Payment Network
+
+Default network: `base`
+
+Default facilitator:
+
+```text
+https://facilitator.daydreams.systems
+```
+
+The payment receiver is configured by `PAYMENTS_RECEIVABLE_ADDRESS`.
+
+## Cost Comparison
+
+| Provider | Typical agent-search price | Account required | Native x402 | Structured JSON |
+| --- | ---: | --- | --- | --- |
+| Queryx web/news | `0.001` USDC | No | Yes | Yes |
+| Queryx deep | `0.005` USDC | No | Yes | Yes |
+| Tavily | Around `$0.004` per search credit | Yes | No | Yes |
+| Perplexity Sonar | Around `$0.005` to `$0.014` per request class | Yes | No | Yes |
+| Brave Search API | Plan-dependent | Yes | No | Source results only |
+
+## Agent Budgeting Examples
+
+| Workload | Endpoint mix | Estimated cost |
+| --- | --- | ---: |
+| 100 general searches | 100 x `/v1/search` | `0.100` USDC |
+| 100 news checks | 100 x `/v1/search/news` | `0.100` USDC |
+| 20 research tasks | 20 x `/v1/search/deep` | `0.100` USDC |
+| Mixed daily monitor | 80 web + 20 news + 5 deep | `0.125` USDC |
+
+## Notes For Agents
+
+- Always read the live `402` challenge before paying. It is the source of truth for price, network, receiver, and facilitator.
+- Prices in this document are the intended defaults; deployments can override receiver and network configuration.
+- If a request fails before settlement, do not assume a charge occurred. Use the facilitator response and wallet transaction state as the payment record.
+

--- a/docs/XGATE_LISTING.md
+++ b/docs/XGATE_LISTING.md
@@ -1,0 +1,62 @@
+# xgate.run Listing Metadata
+
+Use this copy when submitting Queryx to the xgate.run bazaar.
+
+## Name
+
+Queryx
+
+## Short Description
+
+Agent-native x402 search API for web, news, and deep research.
+
+## Long Description
+
+Queryx gives agents paid, accountless search over HTTP. Agents receive an x402 payment challenge, settle in USDC, and retry the same request to get structured JSON with a synthesized answer, source links, freshness metadata, confidence, model ID, and token usage.
+
+## Category
+
+Search
+
+## Tags
+
+```text
+x402, search, news, research, agents, usdc, base, openapi
+```
+
+## Production URL
+
+```text
+https://queryx.run
+```
+
+## OpenAPI URL
+
+```text
+https://queryx.run/openapi.json
+```
+
+If the deployment does not serve the file directly yet, use the repository copy:
+
+```text
+https://github.com/langoustine69/queryx/blob/main/openapi.json
+```
+
+## Pricing
+
+- `GET /v1/search`: `0.001` USDC
+- `GET /v1/search/news`: `0.001` USDC
+- `POST /v1/search/deep`: `0.005` USDC
+
+## Health Check
+
+```text
+GET /health
+```
+
+Expected response:
+
+```json
+{ "status": "ok" }
+```
+

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,520 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Queryx Agent Search API",
+    "version": "0.1.0",
+    "summary": "Agent-native paid search endpoints using x402 payments.",
+    "description": "Queryx exposes web, news, and deep search endpoints that return structured JSON for agents. Paid endpoints require an x402 payment header before execution."
+  },
+  "servers": [
+    {
+      "url": "https://queryx.run",
+      "description": "Production"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Search",
+      "description": "Paid agent search endpoints"
+    },
+    {
+      "name": "System",
+      "description": "Free operational endpoints"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "x402Payment": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-PAYMENT",
+        "description": "x402 payment payload returned from the preceding 402 challenge. PAYMENT and PAYMENT-SIGNATURE are also accepted for compatible clients."
+      }
+    },
+    "schemas": {
+      "Source": {
+        "type": "object",
+        "required": ["title", "url", "snippet"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "examples": ["Result for bitcoin ETF flows"]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "examples": ["https://example.com/queryx-result"]
+          },
+          "snippet": {
+            "type": "string",
+            "examples": ["A concise source excerpt used for synthesis."]
+          },
+          "published": {
+            "type": "string",
+            "format": "date-time",
+            "examples": ["2026-05-11T04:00:00.000Z"]
+          }
+        }
+      },
+      "Freshness": {
+        "type": "object",
+        "required": ["fetchedAt", "resultsAge"],
+        "properties": {
+          "fetchedAt": {
+            "type": "string",
+            "format": "date-time",
+            "examples": ["2026-05-11T04:00:00.000Z"]
+          },
+          "resultsAge": {
+            "type": "string",
+            "examples": ["1 hour"]
+          }
+        }
+      },
+      "TokenUsage": {
+        "type": "object",
+        "required": ["in", "out"],
+        "properties": {
+          "in": {
+            "type": "integer",
+            "minimum": 0,
+            "examples": [31]
+          },
+          "out": {
+            "type": "integer",
+            "minimum": 0,
+            "examples": [256]
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "required": [
+          "query",
+          "answer",
+          "sources",
+          "confidence",
+          "freshness",
+          "model",
+          "tokens"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "examples": ["bitcoin ETF flows"]
+          },
+          "answer": {
+            "type": "string",
+            "examples": ["Bitcoin ETF flow data shows steady institutional demand across recent sessions."]
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "examples": [0.78]
+          },
+          "freshness": {
+            "$ref": "#/components/schemas/Freshness"
+          },
+          "model": {
+            "type": "string",
+            "examples": ["queryx-fast-v1"]
+          },
+          "tokens": {
+            "$ref": "#/components/schemas/TokenUsage"
+          }
+        }
+      },
+      "DeepSearchRequest": {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "examples": ["Compare Brave, Tavily, and Perplexity pricing for agent search"]
+          },
+          "depth": {
+            "type": "string",
+            "enum": ["standard", "deep"],
+            "default": "deep",
+            "examples": ["deep"]
+          }
+        }
+      },
+      "PaymentChallenge": {
+        "type": "object",
+        "required": ["price", "payTo", "network", "facilitatorUrl", "x402Version"],
+        "properties": {
+          "price": {
+            "type": "string",
+            "examples": ["0.001"]
+          },
+          "payTo": {
+            "type": "string",
+            "examples": ["0x0000000000000000000000000000000000000000"]
+          },
+          "network": {
+            "type": "string",
+            "examples": ["base"]
+          },
+          "facilitatorUrl": {
+            "type": "string",
+            "format": "uri",
+            "examples": ["https://facilitator.daydreams.systems"]
+          },
+          "x402Version": {
+            "type": "integer",
+            "examples": [2]
+          }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["code", "message"],
+            "properties": {
+              "code": {
+                "type": "string",
+                "examples": ["PAYMENT_REQUIRED"]
+              },
+              "message": {
+                "type": "string",
+                "examples": ["x402 payment is required for this endpoint"]
+              },
+              "details": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PaymentChallenge"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "PaymentRequired": {
+        "description": "x402 payment challenge. Sign the challenge and retry with X-PAYMENT, PAYMENT, or PAYMENT-SIGNATURE.",
+        "headers": {
+          "WWW-Authenticate": {
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 challenge header."
+          },
+          "X-Accepted-Payment": {
+            "schema": {
+              "type": "string"
+            },
+            "description": "Serialized x402 payment requirements."
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "examples": {
+              "challenge": {
+                "value": {
+                  "error": {
+                    "code": "PAYMENT_REQUIRED",
+                    "message": "x402 payment is required for this endpoint",
+                    "details": {
+                      "price": "0.001",
+                      "payTo": "0x0000000000000000000000000000000000000000",
+                      "network": "base",
+                      "facilitatorUrl": "https://facilitator.daydreams.systems",
+                      "x402Version": 2
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Invalid query or body.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "examples": {
+              "missingQuery": {
+                "value": {
+                  "error": {
+                    "code": "BAD_REQUEST",
+                    "message": "Query is required"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "The client has exceeded the current rate limit.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "examples": {
+              "rateLimit": {
+                "value": {
+                  "error": {
+                    "code": "RATE_LIMITED",
+                    "message": "Rate limit exceeded"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Search provider or synthesis failure.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            },
+            "examples": {
+              "serverError": {
+                "value": {
+                  "error": {
+                    "code": "INTERNAL_ERROR",
+                    "message": "Search failed"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": ["System"],
+        "summary": "Health check",
+        "description": "Free readiness check for deployment platforms and agent registries.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "Service is healthy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": ["ok"]
+                    }
+                  }
+                },
+                "examples": {
+                  "healthy": {
+                    "value": {
+                      "status": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/search": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Paid web search",
+        "description": "Runs a web search and returns an agent-ready synthesized answer with sources.",
+        "operationId": "searchWeb",
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "examples": {
+              "market": {
+                "value": "Fed rate decision impact on tech stocks"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search answer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/v1/search/news": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Paid news search",
+        "description": "Runs a news-focused search sorted toward recent sources.",
+        "operationId": "searchNews",
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "examples": {
+              "news": {
+                "value": "latest ethereum ETF inflows"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "News answer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/v1/search/deep": {
+      "post": {
+        "tags": ["Search"],
+        "summary": "Paid deep search",
+        "description": "Runs a deeper multi-source search and synthesis pass for research-style questions.",
+        "operationId": "searchDeep",
+        "security": [
+          {
+            "x402Payment": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeepSearchRequest"
+              },
+              "examples": {
+                "deepResearch": {
+                  "value": {
+                    "query": "Compare Brave, Tavily, and Perplexity pricing for agent search",
+                    "depth": "deep"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deep search answer.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "422": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
/claim #5

Implements the agent discovery deliverables for the TaskMarket bounty:

- Adds `openapi.json` with OpenAPI 3.1 coverage for `/v1/search`, `/v1/search/news`, `/v1/search/deep`, and `/health`.
- Adds `docs/AGENT_GUIDE.md` with x402 payment flow, retry behavior, examples, error handling, and agent best practices.
- Adds `docs/PRICING.md` with endpoint prices in USDC and base-unit equivalents.
- Adds `docs/XGATE_LISTING.md` with ready-to-submit xgate.run bazaar metadata.
- Links all discovery docs from the README.

Verification:
- `node -e "JSON.parse(require('fs').readFileSync('openapi.json','utf8')); console.log('openapi ok')"`
- `bun test` (31 pass)

Note: the current `main` branch does not define a `typecheck` script, so I could not run `bun run typecheck` on this isolated docs branch.

Payout address: `0x2E4380d2e1668Ca9fA3Ef91fF776FDc140Cf3fE8` (EVM/Base-compatible USDC).