### PR TITLE
Add Railway deployment and CI setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+node_modules/
+.env
+.env.*
+!.env.example
+dist/
+coverage/
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Server
+# Port the Bun server listens on locally. Railway supplies this automatically.
+PORT=3000
+# Host interface for the Bun server. Use 0.0.0.0 for container/Railway deploys.
+HOST=0.0.0.0
+
+# Search and synthesis providers
+# Brave Search API key used to fetch source results.
+BRAVE_API_KEY=brave_api_key_here
+# OpenAI API key used for result synthesis.
+OPENAI_API_KEY=openai_api_key_here
+# Cache lifetime for repeated search responses, in seconds.
+CACHE_TTL_SECONDS=300
+
+# x402 payment configuration
+# x402 network name used in 402 responses.
+X402_NETWORK=base
+# Public wallet address that receives x402 USDC payments.
+X402_RECIPIENT_ADDRESS=0x0000000000000000000000000000000000000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+      - name: Type check
+        run: bun run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+.env.*
+!.env.example
+dist/
+coverage/
+.DS_Store

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,60 @@
+# Railway Deployment
+
+This guide deploys Queryx to Railway with the Dockerfile in this repository.
+
+## Prerequisites
+
+- A Railway account
+- Railway CLI installed
+- Required provider keys from `.env.example`
+
+## Steps
+
+1. Install and authenticate the Railway CLI:
+
+   ```bash
+   npm install -g @railway/cli
+   railway login
+   ```
+
+2. Create or link a Railway project:
+
+   ```bash
+   railway init
+   ```
+
+3. Add the required environment variables in the Railway dashboard:
+
+   - `BRAVE_API_KEY`
+   - `OPENAI_API_KEY`
+   - `CACHE_TTL_SECONDS`
+   - `X402_NETWORK`
+   - `X402_RECIPIENT_ADDRESS`
+
+   Railway provides `PORT` automatically, so it is optional in production.
+
+4. Deploy:
+
+   ```bash
+   railway up
+   ```
+
+5. Configure a custom domain:
+
+   - Open the Railway service settings.
+   - Add `queryx.run` under Networking.
+   - Point your DNS record to the Railway-provided target.
+
+6. Verify the deployment:
+
+   ```bash
+   bash scripts/smoke-test.sh https://queryx.run
+   ```
+
+## Health Check
+
+Railway uses `/health` as configured in `railway.json`. A healthy service returns:
+
+```json
+{ "status": "ok" }
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM oven/bun:1 AS base
+
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD bun -e "const response = await fetch('http://localhost:3000/health'); if (!response.ok) process.exit(1)"
+
+CMD ["bun", "run", "src/index.ts"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Queryx 🔍
 
+[![CI](https://github.com/langoustine69/queryx/actions/workflows/ci.yml/badge.svg)](https://github.com/langoustine69/queryx/actions/workflows/ci.yml)
+
 > Agent-native search API. Pay per query in USDC via x402. No accounts. No subscriptions. Structured JSON.
 
 **5-14x cheaper than Perplexity. Native x402 payments. Zero friction for agents.**
@@ -27,6 +29,16 @@ curl -H "PAYMENT-SIGNATURE: <x402-sig>" \
 - GPT-4o-mini — synthesis
 - Railway — hosting
 - Base Mainnet — USDC payments
+
+## Deployment
+
+Railway deployment is configured with `Dockerfile` and `railway.json`.
+Copy `.env.example` into your Railway service variables, deploy with `railway up`,
+then run:
+
+```bash
+bash scripts/smoke-test.sh https://queryx.run
+```
 
 ## Competitive Positioning
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "queryx",
       "devDependencies": {
         "@types/bun": "latest",
+        "typescript": "^6.0.3",
       },
     },
   },
@@ -15,6 +16,8 @@
     "@types/node": ["@types/node@25.3.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
   }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "dev": "bun run src/index.ts",
+    "start": "bun run src/index.ts",
     "test": "bun test",
-    "dev": "bun run src/index.ts"
+    "typecheck": "tsc --noEmit",
+    "smoke": "bash scripts/smoke-test.sh"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "typescript": "^6.0.3"
   }
 }

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 10,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+
+health_body=""
+for _ in {1..30}; do
+  if health_body="$(curl -fsS "${BASE_URL}/health" 2>/dev/null)"; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "${health_body}" ]]; then
+  echo "Timed out waiting for ${BASE_URL}/health" >&2
+  exit 1
+fi
+
+if [[ "${health_body}" != *'"status":"ok"'* && "${health_body}" != *'"status": "ok"'* ]]; then
+  echo "Unexpected /health response: ${health_body}" >&2
+  exit 1
+fi
+
+response_headers="$(mktemp)"
+response_body="$(mktemp)"
+trap 'rm -f "${response_headers}" "${response_body}"' EXIT
+
+status_code="$(
+  curl -sS -o "${response_body}" \
+    -D "${response_headers}" \
+    -w "%{http_code}" \
+    "${BASE_URL}/v1/search?q=smoke"
+)"
+
+if [[ "${status_code}" != "402" ]]; then
+  echo "Expected /v1/search to return 402, got ${status_code}" >&2
+  cat "${response_body}" >&2
+  exit 1
+fi
+
+if ! grep -qi '^x-402-network:' "${response_headers}"; then
+  echo "Missing x-402-network header" >&2
+  cat "${response_headers}" >&2
+  exit 1
+fi
+
+if ! grep -qi '^x-402-price-usdc:' "${response_headers}"; then
+  echo "Missing x-402-price-usdc header" >&2
+  cat "${response_headers}" >&2
+  exit 1
+fi
+
+echo "Smoke test passed for ${BASE_URL}"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,81 @@
+const port = Number(process.env.PORT ?? 3000);
+const hostname = process.env.HOST ?? "0.0.0.0";
+
+type PaidRoute = {
+  path: string;
+  method: string;
+  price: string;
+};
+
+const paidRoutes: PaidRoute[] = [
+  { method: "GET", path: "/v1/search", price: "0.001" },
+  { method: "GET", path: "/v1/search/news", price: "0.001" },
+  { method: "POST", path: "/v1/search/deep", price: "0.005" },
+];
+
+function json(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+function paymentRequired(route: PaidRoute): Response {
+  const network = process.env.X402_NETWORK ?? "base";
+  const recipient = process.env.X402_RECIPIENT_ADDRESS ?? "";
+
+  return json(
+    {
+      error: "payment_required",
+      message: "This Queryx endpoint requires an x402 USDC payment.",
+      accepts: [
+        {
+          scheme: "exact",
+          network,
+          amount: route.price,
+          asset: "USDC",
+          payTo: recipient,
+        },
+      ],
+    },
+    {
+      status: 402,
+      headers: {
+        "x-402-network": network,
+        "x-402-price-usdc": route.price,
+        "x-402-recipient": recipient,
+      },
+    },
+  );
+}
+
+function findPaidRoute(request: Request): PaidRoute | undefined {
+  const url = new URL(request.url);
+  return paidRoutes.find(
+    (route) => route.method === request.method && route.path === url.pathname,
+  );
+}
+
+Bun.serve({
+  port,
+  hostname,
+  fetch(request) {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ status: "ok" });
+    }
+
+    const paidRoute = findPaidRoute(request);
+    if (paidRoute) {
+      return paymentRequired(paidRoute);
+    }
+
+    return json({ error: "not_found" }, { status: 404 });
+  },
+});
+
+console.log(`Queryx listening on http://${hostname}:${port}`);

--- a/tests/logic/brave.test.ts
+++ b/tests/logic/brave.test.ts
@@ -11,7 +11,7 @@ function mockFetch(response: any, status = 200) {
       statusText: status === 200 ? "OK" : "Error",
       json: () => Promise.resolve(response),
     } as Response)
-  );
+  ) as unknown as typeof fetch;
 }
 
 beforeEach(() => {


### PR DESCRIPTION
Closes #4

Summary:
- Add Dockerfile and railway.json for Railway deployment with /health checks
- Add .env.example, DEPLOY.md, README deployment notes, and CI badge
- Add GitHub Actions CI for Bun install, tests, and typecheck
- Add a minimal Bun service entrypoint with /health and 402/x402 headers for paid search routes
- Add a post-deploy smoke test for /health and unauthenticated /v1/search 402 behavior

Validation:
- bun test
- bun run typecheck
- bash scripts/smoke-test.sh http://local-host:3004
- docker build -t queryx-railway-smoke .
- git diff --check